### PR TITLE
Add java security provider method to be added seamlessly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ allprojects {
 
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'org.bouncycastle', name: 'bcprov-jdk15on', version: '1.70'
 }
 
 java {

--- a/src/main/java/io/github/felipebonezi/cipherizy/algorithm/CipherFactory.java
+++ b/src/main/java/io/github/felipebonezi/cipherizy/algorithm/CipherFactory.java
@@ -1,6 +1,8 @@
 package io.github.felipebonezi.cipherizy.algorithm;
 
 import io.github.felipebonezi.cipherizy.ICipher;
+import java.security.Provider;
+import java.security.Security;
 
 /**
  * Factory method pattern to generate {@link ICipher} implementations to encrypt or decrypt some data.
@@ -48,6 +50,33 @@ public class CipherFactory {
             return new AESCipher();
         }
         throw new IllegalArgumentException("Algorithm not found: " + algorithm);
+    }
+    
+    /**
+     * Designed to use a provider-based architecture, the JCE allows for qualified cryptography
+     * libraries such as BouncyCastle to be plugged in as security providers and new algorithms
+     * to be added seamlessly.
+     * <p>
+     * We can add a security provider either statically or dynamically.
+     * To add a new Provider statically, we modify the `java.security` file located in
+     * <JAVA_HOME>/jre/lib/security folder.
+     * <p>
+     * We add the line at the end of the list:
+     * security.provider.4=com.sun.net.ssl.internal.ssl.Provider
+     * security.provider.5=com.sun.crypto.provider.SunJCE
+     * security.provider.6=sun.security.jgss.SunProvider
+     * security.provider.7=org.bouncycastle.jce.provider.BouncyCastleProvider
+     *
+     * @param provider       Required security provider.
+     * @param otherProviders Optional security providers.
+     */
+    public void addSecurityProviders(Provider provider, Provider... otherProviders) {
+        Security.addProvider(provider);
+        if (otherProviders != null && otherProviders.length > 0) {
+            for (Provider otherProvider : otherProviders) {
+                Security.addProvider(otherProvider);
+            }
+        }
     }
     
     /** Algorithms. */

--- a/src/test/java/io/github/felipebonezi/cipherizy/test/CipherTest.java
+++ b/src/test/java/io/github/felipebonezi/cipherizy/test/CipherTest.java
@@ -1,6 +1,7 @@
 package io.github.felipebonezi.cipherizy.test;
 
 import io.github.felipebonezi.cipherizy.algorithm.CipherFactory;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -11,12 +12,18 @@ public class CipherTest {
     CipherFactory singleton1    = CipherFactory.getInstance();
     int           hashCodeInst1 = singleton1.hashCode();
     Assert.assertNotNull(singleton1);
-    
+  
     CipherFactory singleton2    = CipherFactory.getInstance();
     int           hashCodeInst2 = singleton2.hashCode();
     Assert.assertNotNull(singleton2);
-    
+  
     Assert.assertEquals(hashCodeInst1, hashCodeInst2);
+  }
+  
+  @Test
+  public void whenAddSingleJCEProvider_thenConfigureSuccessfully() {
+    CipherFactory instance = CipherFactory.getInstance();
+    instance.addSecurityProviders(new BouncyCastleProvider());
   }
   
 }


### PR DESCRIPTION
## What's Changed

<!-- Describe what has changed in your code. -->

## ✨ New feature

- **What is new?**
  - Designed to use a provider-based architecture, the JCE allows for qualified cryptography libraries such as BouncyCastle to be plugged in as security providers and new algorithms to be added seamlessly.
